### PR TITLE
On data containing "{{ }}" tags, that data is being evaluated as part…

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -156,17 +156,17 @@ function transform(templateObj, data, helpers) {
           //console.log('dataArr = ' + JSON.stringify(dataArr));
           //console.log('template = ' + JSON.stringify(template));
           var outputArr = mapArray(dataArr, template, helpers);
-          this.update(outputArr);
+          this.update(outputArr, true);
         }
         else {
-          this.update(dataArr);
+          this.update(dataArr, true);
         }
       }
     }
 
     else if (typeof node === 'string') {
       if (node.indexOf('{{') !== -1) {
-        this.update(getActualValue(node, data));
+        this.update(getActualValue(node, data), true);
         return;
       }
 


### PR DESCRIPTION
… of the template. We set traverse.update's stopHere parameter to true to stop that evaluation.

Consider this data:

```
{
    "items": [
        {
            "foo": {
                "bar1": "hello",
                "bar2": "{{resolves_to_empty_string}}"
            }
        },
        {
            "foo": {
                "bar1": "hello",
                "bar2": "{{{Causes 'Unexpected token' error}}}"
            }
        }
    ]
}
```

With this map:

```
{
    "items": [
        "{{items}}",
        {
            "c": "{{foo.bar2}}",
            "d": "literal text",
            "e": "hello {{foo.bar2}} again"
        }
    ]
}
```

This demonstrates the problem: the data is being treated as part of the map. The desired behavior is to return the data even when it contains braces.