### PR TITLE
Fix if arguments contain ")" - possible for strings

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -201,9 +201,9 @@ function transform(templateObj, data, helpers) {
         var fn = node.split('=>')[1];
         //fn = fn.replace(/ /g,'');
         fn = fn.trim(); // remove leading & trailing spaces
-        var pieces = fn.split('(');
-        var fnName = pieces[0];
-        var argStr = pieces[1].split(')')[0];
+        var argStart = fn.indexOf("(");
+        var fnName = fn.substr(0, argStart);
+        var argStr = fn.substr(argStart + 1, fn.length - argStart - 2);
         var args = argStr.split(',');
         var argArr = [];
         if (args) {


### PR DESCRIPTION
In my case, I needed to pass a string as a parameter that contained values such as "(test)". The code was failing as it terminated the search for arguments at the first ")". 